### PR TITLE
Add onboarding doc

### DIFF
--- a/manual/onboarding.md
+++ b/manual/onboarding.md
@@ -1,0 +1,9 @@
+# Onboarding
+
+This document describes how to engage with the Wardley Mapping Foundation.
+
+## Trustees
+
+### Make yourself publically visible as a member of the Wardley Mapping Foundation GitHub organization
+
+In line with our principle of openess please follow [this GitHub doc](https://help.github.com/articles/publicizing-or-hiding-organization-membership/) to make yourself publically visible as a member of the Wardley Mapping Foundation GitHub organization.


### PR DESCRIPTION
This resolves #12 by adding a markdown document called onboarding to a folder called manual.

This is my first ever pull request, and I'd be grateful for feedback.