### PR TITLE
Add a Markdown template for the minutes

### DIFF
--- a/manual/template_minutes.md
+++ b/manual/template_minutes.md
@@ -1,0 +1,15 @@
+# Meeting on YYYY-MM-DD (Tuesday)
+
+## Logistics
+
+- Where: Online via [Meetup](https://www.meetup.com/wardley-mapping-foundation/events/289644918/)
+- When: 15:00 to 15:30 GMT
+- Attending: add names with Twitter or GitHub links here e.g. `(Name)[https://twitter.com/@Name]`
+
+## Follow-ups and direction
+
+- [ ] add follow-ups as check boxes `- [ ]`
+
+## Discussions
+
+- add discussions as bullets


### PR DESCRIPTION
This is a PR to suggest adding a template for the minutes.

I think the minutes are helpful in async communications for our work.

I hope the template might allow volunteers new to writing minutes or using Markdown to see what information we include in the minutes, and how we format them.

Question: I'm not sure if the manual folder is the right place for these?